### PR TITLE
Add back support for Google Compute Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ docs/_build/
 
 # Production file with passwords
 production.env
+
+# Certificates
+*.p12
+*.pkcs12
+*.pem
+*.crt

--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # Ansible deployment for Biostar-based projects
 
+## 0. QuickStart
+
+XXX: Super brief way to deploy all this (between 1 and 3 steps, no more), i.e
+
+``
+ansible-playbook gce.yml --extra-vars="gce_service_email=<SERVICE_ACCOUNT_EMAIL> gce_prj_name=<PRJ_NAME>" -i /etc/ansible/hosts
+``
+
 ## 1. Overview
-An Ansible playbook to automatize the deployment of a [Biostar-based](https://github.com/ialbert/biostar-central) project to an Amazon EC2 instance using Docker containers.
+
+An Ansible playbook to automate the deployment of a [Biostar-based](https://github.com/ialbert/biostar-central) project to an Amazon EC2 or GCE instances using Docker containers.
 
 The tasks performed by the playbook are:
 
-- create a new Amazon Security Group with open ports 22, 80, 443.
-- create a new Amazon Key Pair with the public SSH key of the machine used to run Ansible.
-- launch a new Amazon EC2 instance with the provided features.
-- install Docker in the instance.
+- Create security Group with open ports 22, 80, 443.
+- Create an Amazon Key Pair with the public SSH key of the machine used to run Ansible.
+- Launch an Amazon EC2 instance.
+- Install Docker in the instance.
 - Build and run a Docker container with PostgreSQL 9.3.
 - Build and run a Docker container with [waitress](http://waitress.readthedocs.org/en/latest/) webserver running the provided codebase. 
 
 ## 2. Requirements
+
 You need Ansible to be installed in the local machine.
 The best way to install it is to start a Python 2.7 virtual environment and then:
+
 ```
 pip install ansible
 ```
@@ -22,17 +33,18 @@ pip install ansible
 *Note*: during the deployment `boto` and `git` will be installed in the local machine (in the virtual environment in this case).
 
 ## 3. Usage
-1. Clone this repo
+
+1. `git clone http://github.com/nimiq/ansible-biostar`
 2. Use your custom Django configuration:
-  - copy the file [roles/docker_webapp/files/conf/production.env.template](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/files/conf/production.env.template) to `production.env` in the same folder and edit its `CUSTOM SECTION`.   
+  - Copy the file [roles/docker_webapp/files/conf/production.env.template](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/files/conf/production.env.template) to `production.env` in the same folder and edit its `CUSTOM SECTION`.   
 *Note*: `production.env` is ignored by git, so your passwords are safe!
-  - edit the `CUSTOM SECTION` of [roles/docker_webapp/templates/biostar/settings/production.py.j2](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/templates/biostar/settings/production.py.j2)
-  - add your favicon replacing the file: [roles/docker_webapp/files/biostar/static/favicon.ico](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/files/biostar/static/favicon.ico)
+  - Edit the `CUSTOM SECTION` of [roles/docker_webapp/templates/biostar/settings/production.py.j2](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/templates/biostar/settings/production.py.j2)
+  - Add your favicon replacing the file: [roles/docker_webapp/files/biostar/static/favicon.ico](https://github.com/nimiq/ansible-biostar/blob/master/roles/docker_webapp/files/biostar/static/favicon.ico)
 3. Run the Ansible playbook, the basic usage is:
+
 ```
 ansible-playbook site.yml --extra-vars "aws_access_key=YOUR_KEY aws_secret_key=YOUR_SECRET"
 ```
-
 
 Ansible will output the IP address of the launched EC2 instance.
 When the playbook is completed, you can then visit your new website at that address (on port 80).
@@ -42,6 +54,7 @@ On a t1.micro instance it takes about 12 mins.
 *Note*: we are trying to move all the custom parts to `production.env` so that there is only one file to edit.
 
 ### 3.1. Playbook Advanced Arguments
+
 The are 2 groups of arguments for the playbook.
 
 **Amazon AWS**: arguments to define the new EC2 instance that will be launched.
@@ -64,31 +77,39 @@ The are 2 groups of arguments for the playbook.
 - `git_branch`: Branch name. Default: master.
 
 Example:
+
 ```
 ansible-playbook site.yml --extra-vars "aws_access_key=HKJHJK aws_secret_key=ghjGHJgjHGJ volume_size=8 postgresql_username=superman postgresql_password=fgHGFHGhgfh git_https_repo=https://github.com/my_user/biostar-central.git git_branch=new-deployment"
 ```
 
 ## 4. SSH Connections
+
 You can SSH into the EC2 instance and into the 2 Docker containers.
 
 ### 4.1. SSH Into The EC2 Instance
+
 ```
 ssh ubuntu@<INSTANCE_IP>
 ```
 Ansible will output the instance IP.
 
 ### 4.2. SSH Into The Docker Containers
+
 First SSH to the EC2 instance.  
 Then you can either SSH into the webapp container:  
+
 ```
 ssh root@127.0.0.1 -p 2222
 ```
+
 Or SSH into the PostgreSQL container:  
+
 ```
 ssh root@127.0.0.1 -p 2223
 ```
 
 ## 5. Container persistence
+
 The PostgreSQL data directory and logs are stored in the EC2 instance at: `/home/ubuntu/workspace/docker-volumes/pgdata`.   
 The codebase is at: `/home/ubuntu/workspace/biostar`.   
 Logs of the web app are at: `/home/ubuntu/workspace/biostar/live/logs`.   
@@ -96,6 +117,7 @@ Django media files are at: `/home/ubuntu/workspace/biostar/live/export/media`.
 
 ## 6. Code Updates and Maintenance
 ### 6.1. Basic Code Updates
+
 - SSH into the EC2 instance
 - `cd /home/ubuntu/workspace/biostar`
 - Do your code edits/updates, f.i.: `git pull`
@@ -103,8 +125,10 @@ Django media files are at: `/home/ubuntu/workspace/biostar/live/export/media`.
 - `docker webapp start`
 
 ### 6.2. Proper Maintenance
+
 - SSH into the webapp Docker container
 - Stop the webapp Runit service, kill waitress-serve, source the env vars, do the mainainance, restart the webapp Runit service:
+
 ```
 sv stop webapp
 killall -9 waitress-serve
@@ -118,11 +142,14 @@ python manage.py my_maintenance
 
 sv start webapp
 ```
+
 *Note*: changes are saved into the container (by meaning if you create/edit a file, the new changes are saved in the container even after a `docker stop` - the new changes are lost only if you *remove* the container `docker rm webapp`)
 
 ## 7. Docker container start and stop
+
 If you want to start/stop a webapp container first SSH to the EC2 instance.  
 Then run:
+
 ```
 docker stop webapp
 docker start webapp
@@ -131,14 +158,16 @@ docker start webapp
 *Note*: stopping a container does NOT make you lose the data you edited in that container. Only removing a container wirh `docker rm webapp` makes you lose the data you edited in that container.
 
 ### 7.1. Restart webapp container
+
 Restarting the webapp container causes `run_webapp.sh` to be run again.
 This means that the following tasks will be executed:
-- install requirements
+
+- Install requirements
 - `source conf/production.env`
-- create the database if it does not exist
-- migrate the database
-- if the database has just been created: load the fixture and rebuild the index
-- collect static files
-- run waitress-serve
+- Create the database if it does not exist
+- Migrate the database
+- If the database has just been created: load the fixture and rebuild the index
+- Collect static files
+- Run waitress-serve
 
 Note that there is no `git pull`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ TODO: Brief way to deploy all this between 1 and 3 steps, no more. Oneliners pre
 Should cover all supported cloud services, i.e:
 
 ``
+ansible-galaxy install nimiq.ansible-biostar
+
 ansible-playbook site.yml --extra-vars "cloud_provider=aws aws_access_key=YOUR_KEY aws_secret_key=YOUR_SECRET"
 ansible-playbook site.yml --extra-vars="cloud_provider=gce gce_service_email=<SERVICE_ACCOUNT_EMAIL> gce_prj_name=<PRJ_NAME>" -i /etc/ansible/hosts
 ``

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 ## 0. QuickStart
 
-XXX: Super brief way to deploy all this (between 1 and 3 steps, no more), i.e
+TODO: Brief way to deploy all this between 1 and 3 steps, no more. Oneliners preferred here.
+
+Should cover all supported cloud services, i.e:
 
 ``
-ansible-playbook gce.yml --extra-vars="gce_service_email=<SERVICE_ACCOUNT_EMAIL> gce_prj_name=<PRJ_NAME>" -i /etc/ansible/hosts
+ansible-playbook site.yml --extra-vars "cloud_provider=aws aws_access_key=YOUR_KEY aws_secret_key=YOUR_SECRET"
+ansible-playbook site.yml --extra-vars="cloud_provider=gce gce_service_email=<SERVICE_ACCOUNT_EMAIL> gce_prj_name=<PRJ_NAME>" -i /etc/ansible/hosts
 ``
 
 ## 1. Overview

--- a/gce.yml
+++ b/gce.yml
@@ -1,42 +1,7 @@
-# TODO: This is an old version. It needs to be edited in order to work with the new Ansible playbook.
 ---
-- name: "Create GCE instance"
-  hosts: localhost
+- hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: False
 
-  tasks:
-   - name: "Convert the GCE .p12 file to .pem RSA key"
-     local_action: shell openssl pkcs12 -in templates/gce-private-notasecret.p12 -passin pass:notasecret -nodes -nocerts | openssl rsa -out templates/pkey.pem
-
-   - name: "Download CA keychain for apache-libcloud"
-     local_action: command wget https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt -O templates/ca-bundle.crt
-
-   - name: "Launch instances"
-     environment:
-        SSL_CERT_FILE: templates/ca-bundle.crt
-     gce:
-         instance_names: biostar
-         machine_type: n1-standard-1
-         image: debian-7
-         service_account_email: "{{ gce_dev_id }}"
-         pem_file: templates/pkey.pem
-         project_id: "{{ gce_prj_id }}"
-     register: gce
-
-   - name: "Wait for SSH to come up"
-     wait_for: host={{ item.public_ip }} port=22 delay=10 timeout=60
-     with_items: gce.instance_data
-
-   - name: "Group newly created instances"
-     add_host: hostname={{ item.public_ip }} groupname=new_instances
-     with_items: gce.instance_data
-
-   - name: "Add host public key to GCE instance"
-     local_action: shell gcutil --service_version="v1" --project={{ gce_prj_id }} ssh --zone="us-central1-a" "biostar"
-
-- name: "Manage new instances"
-  hosts: new_instances
-  connection: ssh
   roles:
-    - ../common
+    - gce_instance

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Paolo Coffetti and Roman Valls Guimera
+  description: "A role that deploys biostar-central, a Q&A stackexchange-like website"
+  license: GPLv3
+  min_ansible_version: 1.6
+  platforms:
+    - name: Ubuntu
+      versions:
+      - saucy
+  categories:
+    - web

--- a/roles/ec2_instance/tasks/main.yml
+++ b/roles/ec2_instance/tasks/main.yml
@@ -37,14 +37,6 @@
       #   from_port: 6881
       #   to_port: 6889
       #   cidr_ip: 0.0.0.0/0
-    # Outbound rules.
-    # TODO: in some cases (like for INCF's AWS account) it is not possible to create outbound rules.
-    # In such cases, just comment out the `rules_egress:` section.
-    rules_egress:
-      - proto: all
-        from_port: 0
-        to_port: 65535
-        cidr_ip: 0.0.0.0/0
 
 - name: Import key pair 
   ec2_key:

--- a/roles/gce_instance/defaults/main.yml
+++ b/roles/gce_instance/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+site_name: biostars
+image: debian-7
+machine_type: n1-standard-1
+zone: us-central1-a

--- a/roles/gce_instance/tasks/main.yml
+++ b/roles/gce_instance/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: "Convert the GCE .p12 file to .pem RSA key"
+  local_action: shell openssl pkcs12 -in roles/gce_instance/files/gce-private-notasecret.p12 -passin pass:notasecret -nodes -nocerts | openssl rsa -out roles/gce_instance/files/pkey.pem
+
+- name: "Download CA keychain for apache-libcloud"
+  local_action: command wget https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt -O roles/gce_instance/files/ca-bundle.crt
+
+- name: "Launch Google Compute Engine instance"
+  environment:
+     SSL_CERT_FILE: roles/gce_instance/files/ca-bundle.crt
+  gce:
+      instance_names: "{{ site_name }}"
+      machine_type: "{{ machine_type }}"
+      image: "{{ image }}"
+      service_account_email: "{{ gce_service_email }}"
+      pem_file: roles/gce_instance/files/pkey.pem
+      project_id: "{{ gce_prj_name }}"
+  register: gce
+
+- name: "Wait for SSH to come up"
+  wait_for: host={{ item.public_ip }} port=22 delay=10 timeout=60
+  with_items: gce.instance_data
+
+- name: "Group newly created instances"
+  add_host: hostname={{ item.public_ip }} groupname=new_instances
+  with_items: gce.instance_data
+
+- name: "Add host public key to GCE instance"
+  local_action: shell gcutil --service_version="v1" --project={{ gce_prj_id }} ssh --zone={{ zone }} {{ site_name }}


### PR DESCRIPTION
- Add GCE support complying with @nimiq composable module structure. Does not deploy `biostar` inside yet.
- Slightly simplify docs. Add quickstart section.
- Add `meta` to publish role on ansible galaxy.
- Low-prio TODO: Find a way to deploy ansible-biostar in the most cloud-agnostic way possible (see quickstart in `README.md`).
- ~~Low-prio TODO: Investigate and possibly add Google's kubernetes[1] docker to google compute engine module.~~ We do not need scheduling, just docker.

[1] https://github.com/GoogleCloudPlatform/kubernetes
